### PR TITLE
Handle errors when attempting to delete system messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ async function removeMessages(type, target, user){
 
     for (var i = 0; i < messages.length; i++) {
       await removeMessage(messages[i].channel_id, messages[i].id);
-      await sleep(200);
+      await sleep(50);
       bar.tick();
     }
   }

--- a/index.js
+++ b/index.js
@@ -6,10 +6,11 @@ const ENDPOINT = 'https://discordapp.com/api/v6/';
 var headers = {};
 let ignoreChannels = {};
 let ignores = 0
+let offset = 0
 
-async function getMessages(type, target, user) {
+async function getMessages(type, target, user, offset) {
   return JSON.parse(await request({
-    'url': ENDPOINT + type + 's/' + target + '/messages/search?author_id=' + user + '&include_nsfw=true',
+    'url': ENDPOINT + type + 's/' + target + '/messages/search?author_id=' + user + '&include_nsfw=true&offset=' + offset,
     'headers': headers
   }));
 }
@@ -38,7 +39,7 @@ async function removeMessages(type, target, user){
   let bar;
 
   while (true) {
-    let res = await getMessages(type, target, user);
+    let res = await getMessages(type, target, user, offset);
     if (res.hasOwnProperty('document_indexed') && ind == 0) {
       console.log('Not indexed yet. Retrying after 2 seconds.');
       await sleep(2000);
@@ -46,6 +47,8 @@ async function removeMessages(type, target, user){
     }
 
     let messages = res.messages;
+    
+    offset += 25;
 
     if (!bar) { 
       bar = new ProgressBar(':bar :percent :current/:total eta: :eta s', { total: res.total_results });

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ async function removeMessages(type, target, user){
 
     for (var i = 0; i < messages.length; i++) {
       await removeMessage(messages[i].channel_id, messages[i].id);
-      await sleep(50);
+      await sleep(100);
       bar.tick();
     }
   }

--- a/index.js
+++ b/index.js
@@ -67,7 +67,7 @@ async function removeMessages(type, target, user){
 
     for (var i = 0; i < messages.length; i++) {
       await removeMessage(messages[i].channel_id, messages[i].id);
-      await sleep(100);
+      await sleep(200);
       bar.tick();
     }
   }

--- a/index.js
+++ b/index.js
@@ -28,6 +28,7 @@ async function removeMessage(channel_id, id) {
     } catch(e) {
       console.log("Failed to delete message "+id);
       console.log(e.error);
+      offset++;
     }
 }
 
@@ -47,8 +48,6 @@ async function removeMessages(type, target, user){
     }
 
     let messages = res.messages;
-    
-    offset += 25;
 
     if (!bar) { 
       bar = new ProgressBar(':bar :percent :current/:total eta: :eta s', { total: res.total_results });

--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ async function removeMessage(channel_id, id) {
       'headers': headers
     });
     } catch(e) {
-      console.log("Failed to delete message "+id+". Probably a system message?"); 
+      console.log("Failed to delete message "+id+". Probably a system message?");
+      console.log(e);
     }
 }
 

--- a/index.js
+++ b/index.js
@@ -18,11 +18,15 @@ async function removeMessage(channel_id, id) {
   if (ignoreChannels[channel_id])
     ignores++
   else
+    try {
     await request({
       'method': 'DELETE',
       'url': ENDPOINT + 'channels/' + channel_id + '/messages/' + id,
       'headers': headers
     });
+    } catch(e) {
+      console.log("Failed to delete message "+id+". Probably a system message?"); 
+    }
 }
 
 function sleep(ms) {

--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ async function removeMessage(channel_id, id) {
       'headers': headers
     });
     } catch(e) {
-      console.log("Failed to delete message "+id+". Probably a system message?");
-      console.log(e);
+      console.log("Failed to delete message "+id);
+      console.log(e.error);
     }
 }
 


### PR DESCRIPTION
Discord won't let you delete "[name] started a call" messages anymore, and will 403 with a "Can't delete system message".

This code attempts to catch those errors and continue, but in doing so we all need to keep track of the number of undeletable messages and set the offset for finding the next set of messages to delete.

Props also to @woodlehh for testing.